### PR TITLE
Faucet

### DIFF
--- a/charts/devnet/Chart.yaml
+++ b/charts/devnet/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.31
+version: 0.1.32
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/devnet/scripts/setup_genesis.sh
+++ b/charts/devnet/scripts/setup_genesis.sh
@@ -11,19 +11,10 @@ set -eu
 
 jq -r ".genesis[0].mnemonic" $KEYS_CONFIG | $CHAIN_BIN init $CHAIN_ID --chain-id $CHAIN_ID --recover
 
-# Add keys to keyring and self deletegate inital coins
-for type in $(jq -r ". | keys[]" $KEYS_CONFIG)
-do
-  for ((i=0; i<$(jq -r ".$type | length" $KEYS_CONFIG); i++))
-  do
-    echo "Adding key...." $(jq -r ".$type[$i].name" $KEYS_CONFIG)
-    jq -r ".$type[$i].mnemonic" $KEYS_CONFIG | $CHAIN_BIN keys add $(jq -r ".$type[$i].name" $KEYS_CONFIG) --recover --keyring-backend="test"
-    $CHAIN_BIN add-genesis-account $($CHAIN_BIN keys show -a $(jq -r .$type[$i].name $KEYS_CONFIG) --keyring-backend="test") $COINS --keyring-backend="test"
-  done
-done
-
-NUM_KEYS=$($CHAIN_BIN keys list --keyring-backend test --output json | jq -r ". | length")
-echo "Number of keys added to keyring: $NUM_KEYS"
+# Add genesis keys to the keyring and self delegate initial coins
+echo "Adding key...." $(jq -r ".genesis[0].name" $KEYS_CONFIG)
+jq -r ".genesis[0].mnemonic" $KEYS_CONFIG | $CHAIN_BIN keys add $(jq -r ".genesis[0].name" $KEYS_CONFIG) --recover --keyring-backend="test"
+$CHAIN_BIN add-genesis-account $($CHAIN_BIN keys show -a $(jq -r .genesis[0].name $KEYS_CONFIG) --keyring-backend="test") $COINS --keyring-backend="test"
 
 echo "Creating gentx..."
 $CHAIN_BIN gentx $(jq -r ".genesis[0].name" $KEYS_CONFIG) 5000000000$DENOM --keyring-backend="test" --chain-id $CHAIN_ID

--- a/charts/devnet/templates/chain/genesis.yaml
+++ b/charts/devnet/templates/chain/genesis.yaml
@@ -177,13 +177,13 @@ spec:
             - mountPath: /configs
               name: addresses
         - name: faucet
-          image: anmol1696/cosmjs-faucet:latest
+          image: {{ $.Values.faucet.image }}
           imagePullPolicy: Always
           env:
             - name: FAUCET_CONCURRENCY
               value: "10"
             - name: FAUCET_PORT
-              value: "8000"
+              value: "{{ $.Values.faucet.ports.rest }}"
             - name: FAUCET_MEMO
               value: "faucet txn"
             - name: FAUCET_GAS_PRICE
@@ -212,7 +212,7 @@ spec:
               do
                   var="FAUCET_CREDIT_AMOUNT_$(printf '%s\n' ${coin//[[:digit:]]/} | tr '[:lower:]' '[:upper:]')"
                   amt="${coin//[!0-9]/}"
-                  export $var=$((amt/100000))
+                  export $var=$((amt/10000))
               done
 
               export FAUCET_PATH_PATTERN="${HD_PATH:0:$((${#HD_PATH}-1))}a"
@@ -226,11 +226,13 @@ spec:
           volumeMounts:
             - mountPath: /configs
               name: addresses
+          resources:
+{{ toYaml $.Values.faucet.resources | nindent 12 }}
           readinessProbe:
             httpGet:
               path: /status
               port: 8000
-            initialDelaySeconds: 30
+            initialDelaySeconds: 10
             periodSeconds: 10
       volumes:
         - name: node

--- a/charts/devnet/templates/chain/genesis.yaml
+++ b/charts/devnet/templates/chain/genesis.yaml
@@ -176,6 +176,62 @@ spec:
               name: node
             - mountPath: /configs
               name: addresses
+        - name: faucet
+          image: anmol1696/cosmjs-faucet:latest
+          imagePullPolicy: Always
+          env:
+            - name: FAUCET_CONCURRENCY
+              value: "10"
+            - name: FAUCET_PORT
+              value: "8000"
+            - name: FAUCET_MEMO
+              value: "faucet txn"
+            - name: FAUCET_GAS_PRICE
+              value: "0.025{{ $chain.denom }}"
+            - name: FAUCET_GAS_LIMIT
+              value: "2000000"
+            - name: FAUCET_ADDRESS_PREFIX
+              value: "{{ $chain.prefix }}"
+            - name: FAUCET_REFILL_FACTOR
+              value: "8"
+            - name: FAUCET_REFILL_THRESHOLD
+              value: "20"
+            - name: FAUCET_COOLDOWN_TIME
+              value: "0"
+            - name: COINS
+              value: "{{ $chain.coins }}"
+            - name: HD_PATH
+              value: "{{ $chain.hdPath }}"
+          command:
+            - bash
+            - "-c"
+            - |
+              export FAUCET_TOKENS=$(printf '%s\n' ${COINS//[[:digit:]]/})
+
+              for coin in ${COINS//,/ }
+              do
+                  var="FAUCET_CREDIT_AMOUNT_$(printf '%s\n' ${coin//[[:digit:]]/} | tr '[:lower:]' '[:upper:]')"
+                  amt="${coin//[!0-9]/}"
+                  export $var=$((amt/100000))
+              done
+
+              export FAUCET_PATH_PATTERN="${HD_PATH:0:$((${#HD_PATH}-1))}a"
+              export FAUCET_MNEMONIC=$(jq -r ".genesis[0].mnemonic" /configs/keys.json)
+
+              echo "FAUCET_MNEMONIC: $FAUCET_MNEMONIC"
+              echo "FAUCET_PATH_PATTERN: $FAUCET_PATH_PATTERN"
+
+              export | grep "FAUCET"
+              /app/packages/faucet/bin/cosmos-faucet-dist start "http://localhost:26657"
+          volumeMounts:
+            - mountPath: /configs
+              name: addresses
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 10
       volumes:
         - name: node
           emptyDir: { }

--- a/charts/devnet/templates/chain/service.yaml
+++ b/charts/devnet/templates/chain/service.yaml
@@ -20,6 +20,10 @@ spec:
       port: {{ $.Values.exposer.ports.rest | default 8081 }}
       protocol: TCP
       targetPort: {{ $.Values.exposer.ports.rest | default 8081 }}
+    - name: faucet
+      port: 8000
+      protocol: TCP
+      targetPort: 8000
   selector:
     app.kubernetes.io/name: {{ $chain.name }}-genesis
 ---

--- a/charts/devnet/templates/chain/validator.yaml
+++ b/charts/devnet/templates/chain/validator.yaml
@@ -111,6 +111,13 @@ spec:
               jq -r ".validators[$VAL_INDEX].mnemonic" $KEYS_CONFIG | $CHAIN_BIN init $VAL_NAME --chain-id $CHAIN_ID --recover
               jq -r ".validators[$VAL_INDEX].mnemonic" $KEYS_CONFIG | $CHAIN_BIN keys add $VAL_NAME --recover --keyring-backend="test"
 
+              VAL_ADDR=$($CHAIN_BIN keys show $VAL_NAME -a --keyring-backend="test")
+              echo "Transfer tokens to address $VAL_ADDR"
+              curl --header "Content-Type: application/json" \
+                --request POST \
+                --data '{"denom":"'"$DENOM"'","address":"'"$VAL_ADDR"'"}' \
+                http://$GENESIS_HOST.$NAMESPACE.svc.cluster.local:8000/credit
+
               curl http://$GENESIS_HOST.$NAMESPACE.svc.cluster.local:$GENESIS_PORT/genesis -o $CHAIN_DIR/config/genesis.json
               echo "Genesis file that we got....."
               cat $CHAIN_DIR/config/genesis.json

--- a/charts/devnet/templates/relayers/hermes/statefulset.yaml
+++ b/charts/devnet/templates/relayers/hermes/statefulset.yaml
@@ -41,6 +41,10 @@ spec:
               value: /keys/keys.json
             - name: RELAYER_DIR
               value: /root/.hermes
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           command:
             - bash
             - "-c"
@@ -57,14 +61,21 @@ spec:
               {{- range $i, $chain := $relayer.chains }}
               {{- range $fullchain := $.Values.chains }}
               {{- if eq $fullchain.name $chain }}
+              {{ $defaultChain := get $.Values.defaultChains $fullchain.type | default dict }}
+              {{ $fullchain = merge $fullchain $defaultChain }}
               echo "Creating key for {{ $chain }}..."
               hermes keys add \
                 --chain {{ $chain }} \
                 --mnemonic-file $RELAYER_DIR/mnemonic.txt \
                 --key-name {{ $chain }} \
-                {{- with index $.Values.defaultChains $fullchain.type }}
-                --hd-path {{ .hdPath | quote }}
-                {{- end }}
+                --hd-path {{ $fullchain.hdPath | quote }}
+              DENOM="{{ $fullchain.denom }}"
+              RLY_ADDR=$(hermes --json keys list --chain {{ $chain }} | tail -n +2 | jq -r '.result."{{ $chain }}".account')
+              echo "Transfer funds to address $RLY_ADDR"
+              curl --header "Content-Type: application/json" \
+                --request POST \
+                --data '{"denom":"'"$DENOM"'","address":"'"$RLY_ADDR"'"}' \
+                http://{{ $fullchain.name }}-genesis.$NAMESPACE.svc.cluster.local:8000/credit
               {{- end }}
               {{- end }}
               {{- end }}

--- a/charts/devnet/templates/relayers/ts-relayer/configmap.yaml
+++ b/charts/devnet/templates/relayers/ts-relayer/configmap.yaml
@@ -29,7 +29,7 @@ data:
         # Bech32 prefix for addresses
         prefix: {{ $fullchain.prefix }}
         # This determines the gas payments we make (and defines the fee token)
-        gas_price: 0.25{{ $fullchain.denom }}
+        gas_price: 0.025{{ $fullchain.denom }}
         # The path we use to derive the private key from the mnemonic
         # Note: The hd paths shown have no meaningful relationship to the existing chains.
         # It is recommended practice to use a different hd_path than those commonly used for user accounts.

--- a/charts/devnet/templates/relayers/ts-relayer/statefulset.yaml
+++ b/charts/devnet/templates/relayers/ts-relayer/statefulset.yaml
@@ -45,6 +45,10 @@ spec:
               value: /root/.ibc-setup
             - name: KEYS_CONFIG
               value: /keys/keys.json
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           command:
             - bash
             - "-c"
@@ -60,6 +64,22 @@ spec:
               sed -i -e "s/<SRC>/$SRC_CHAIN/g" $RELAYER_DIR/app.yaml
               sed -i -e "s/<DEST>/$DEST_CHAIN/g" $RELAYER_DIR/app.yaml
               sed -i -e "s/<MNEMONIC>/$MNEMONIC/g" $RELAYER_DIR/app.yaml
+
+              {{- range $i, $chain := $relayer.chains }}
+              {{- range $fullchain := $.Values.chains }}
+              {{- if eq $fullchain.name $chain }}
+              {{ $defaultChain := get $.Values.defaultChains $fullchain.type | default dict }}
+              {{ $fullchain = merge $fullchain $defaultChain }}
+              DENOM="{{ $fullchain.denom }}"
+              RLY_ADDR=$(ibc-setup keys list | grep "{{ $fullchain.name }}" | awk '{print $2}')
+              echo "Transfer funds to address $RLY_ADDR"
+              curl --header "Content-Type: application/json" \
+                --request POST \
+                --data '{"denom":"'"$DENOM"'","address":"'"$RLY_ADDR"'"}' \
+                http://{{ $fullchain.name }}-genesis.$NAMESPACE.svc.cluster.local:8000/credit
+              {{- end }}
+              {{- end }}
+              {{- end }}
 
               if [ $RLY_INDEX -eq 0 ]; then
                 echo "Setting up default ics20 channel"

--- a/charts/devnet/values.yaml
+++ b/charts/devnet/values.yaml
@@ -41,6 +41,18 @@ exposer:
       cpu: "0.2"
       memory: "200M"
 
+faucet:
+  image: anmol1696/cosmjs-faucet:latest
+  ports:
+    rest: 8000
+  resources:
+    limits:
+      cpu: "0.2"
+      memory: "200M"
+    requests:
+      cpu: "0.2"
+      memory: "200M"
+
 # Chain timeouts
 timeouts:
   time_iota_ms: 10
@@ -206,10 +218,6 @@ explorer:
     requests:
       cpu: "1"
       memory: "2Gi"
-
-
-faucet:
-  enabled: false
 
 registry:
   enabled: false

--- a/docker/faucet/cosmjs-faucet/Dockerfile
+++ b/docker/faucet/cosmjs-faucet/Dockerfile
@@ -1,0 +1,11 @@
+FROM confio/faucet:0.29.0
+
+# Set up dependencies
+ENV PACKAGES curl make bash jq sed
+
+# Install minimum necessary dependencies
+RUN apk update && apk add --no-cache $PACKAGES
+
+WORKDIR /app
+
+ENTRYPOINT ["/app/packages/faucet/bin/cosmos-faucet-dist"]

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -107,7 +107,7 @@ while [ $# -gt 0 ]; do
       shift # past argument
       ;;
     -*|--*)
-      echo "Unknown option $i"
+      echo "Unknown option $1"
       exit 1
       ;;
     *)

--- a/scripts/port-forward.sh
+++ b/scripts/port-forward.sh
@@ -23,6 +23,7 @@ function stop_port_forward() {
 CHAIN_RPC_PORT=26657
 CHAIN_LCD_PORT=1317
 CHAIN_EXPOSER_PORT=8081
+CHAIN_FAUCET_PORT=8000
 EXPLORER_LCD_PORT=8080
 REGISTRY_LCD_PORT=8080
 REGISTRY_GRPC_PORT=9090
@@ -56,11 +57,13 @@ for i in $(seq 0 $num_chains); do
   localrpc=$(yq -r ".chains[$i].ports.rpc" ${CONFIGFILE} )
   locallcd=$(yq -r ".chains[$i].ports.rest" ${CONFIGFILE} )
   localexp=$(yq -r ".chains[$i].ports.exposer" ${CONFIGFILE})
+  localfaucet=$(yq -r ".chains[$i].ports.faucet" ${CONFIGFILE})
   [[ "$localrpc" != "null" ]] && kubectl port-forward pods/$chain-genesis-0 $localrpc:$CHAIN_RPC_PORT > /dev/null 2>&1 &
   [[ "$locallcd" != "null" ]] && kubectl port-forward pods/$chain-genesis-0 $locallcd:$CHAIN_LCD_PORT > /dev/null 2>&1 &
   [[ "$localexp" != "null" ]] && kubectl port-forward pods/$chain-genesis-0 $localexp:$CHAIN_EXPOSER_PORT > /dev/null 2>&1 &
+  [[ "$localfaucet" != "null" ]] && kubectl port-forward pods/$chain-genesis-0 $localfaucet:$CHAIN_FAUCET_PORT > /dev/null 2>&1 &
   sleep 1
-  color yellow "chains: forwarded $chain lcd to http://localhost:$locallcd, rpc to http://localhost:$localrpc"
+  color yellow "chains: forwarded $chain lcd to http://localhost:$locallcd, rpc to http://localhost:$localrpc, faucet to http://localhost:$localfaucet"
 done
 
 echo "Port forward services"

--- a/scripts/port-forward.sh
+++ b/scripts/port-forward.sh
@@ -16,6 +16,7 @@ function stop_port_forward() {
   for p in $PIDS; do
     kill -15 $p
   done
+  sleep 2
 }
 
 # Default values

--- a/tests/configs/two-chain.yaml
+++ b/tests/configs/two-chain.yaml
@@ -6,6 +6,7 @@ chains:
       rest: 1313
       rpc: 26653
       exposer: 38083
+      faucet: 8001
   - name: cosmoshub-4
     type: cosmos
     numValidators: 2
@@ -13,6 +14,7 @@ chains:
       rest: 1317
       rpc: 26657
       exposer: 38087
+      faucet: 8000
 
 relayers:
   - name: osmos-cosmos

--- a/tests/configs/two-chain.yaml
+++ b/tests/configs/two-chain.yaml
@@ -23,7 +23,7 @@ relayers:
       - cosmoshub-4
 
 explorer:
-  enabled: true
+  enabled: false
   ports:
     rest: 8080
 


### PR DESCRIPTION
## Overview
This is a redesign of how funds are added from to the genesis file even.
With faucet as a mandatory sidecare to the genesis node, we will always run the faucet as the entry point for any new funds being added or created.

Additionally now the slowest process in chain node spinning up was keys being added to the keyring before genesis was created. This no longer is needed, as any of the other nodes spinning up will now just request assets from the faucet and then self initialize.

Even on top of that, now there wont be any limts to the number of validators being created, as new validators can just create new addresses being used.