### PR TITLE
genesis directive for patching `genesis.json`

### DIFF
--- a/.github/actions/e2e-test/action.yaml
+++ b/.github/actions/e2e-test/action.yaml
@@ -77,7 +77,7 @@ runs:
 
     - name: Setup Test infra
       id: starship-action
-      uses: cosmology-tech/starship-action@0.2.11
+      uses: cosmology-tech/starship-action@0.2.15-rc2
       with:
         values: ${{ env.CONFIG_FILE }}
         port-forward: true

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Setup Test infra
         id: starship-action
-        uses: cosmology-tech/starship-action@0.2.12
+        uses: cosmology-tech/starship-action@0.2.15-rc2
         with:
           values: ${{ env.CONFIG_FILE }}
           port-forward: true

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Setup Test infra
         id: starship-action
-        uses: cosmology-tech/starship-action@0.2.14
+        uses: cosmology-tech/starship-action@0.2.15-rc2
         with:
           values: ${{ env.CONFIG_FILE }}
           port-forward: true
@@ -62,7 +62,7 @@ jobs:
 
       - name: Setup Test infra
         id: starship-action
-        uses: cosmology-tech/starship-action@0.2.14
+        uses: cosmology-tech/starship-action@0.2.15-rc2
         with:
           values: ${{ env.CONFIG_FILE }}
           port-forward: true
@@ -99,7 +99,7 @@ jobs:
 
       - name: Setup Test infra
         id: starship-action
-        uses: cosmology-tech/starship-action@0.2.14
+        uses: cosmology-tech/starship-action@0.2.15-rc2
         with:
           values: ${{ env.CONFIG_FILE }}
           port-forward: true

--- a/charts/devnet/templates/chains/cosmos/configmap.yaml
+++ b/charts/devnet/templates/chains/cosmos/configmap.yaml
@@ -9,6 +9,26 @@ data:
     {{- $.Files.Get $path | nindent 4 }}
   {{- end }}
 ---
+{{- range $chain := .Values.chains }}
+{{- if ne $chain.type "virtual" }}
+{{ $defaultFile := $.Files.Get "defaults.yaml" | fromYaml }}
+{{ $defaultScripts := $defaultFile.defaultScripts }}
+{{ $defaultChain := get $defaultFile.defaultChains $chain.type | default dict }}
+
+# merge defaultChain values into the $chain dict
+{{ $chain = merge $chain $defaultChain }}
+{{- if hasKey $chain "genesis" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: patch-{{ $chain.name }}
+data:
+  genesis.json: |-
+    {{ toJson $chain.genesis | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/devnet/templates/chains/cosmos/genesis.yaml
+++ b/charts/devnet/templates/chains/cosmos/genesis.yaml
@@ -112,6 +112,7 @@ spec:
 
               echo "Running setup and config files..."
               bash -e /scripts/setup_genesis.sh
+              jq -s '.[0] * .[1]' $CHAIN_DIR/config/genesis.json /patch/genesis.json > $CHAIN_DIR/config/genesis.json.tmp && mv $CHAIN_DIR/config/genesis.json.tmp $CHAIN_DIR/config/genesis.json
               bash -e /scripts/setup_config.sh
           resources: {{- include "devnet.node.resources" ( dict "node" $chain "context" $ ) | trim | nindent 12 }}
           volumeMounts:
@@ -121,6 +122,8 @@ spec:
               name: addresses
             - mountPath: /scripts
               name: scripts
+            - mountPath: /patch
+              name: patch
       containers:
         - name: validator
           image: {{ $image }}
@@ -253,6 +256,9 @@ spec:
         - name: scripts
           configMap:
             name: setup-scripts
+        - name: patch
+          configMap:
+            name: patch-{{ $chain.name }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/devnet/templates/chains/cosmos/genesis.yaml
+++ b/charts/devnet/templates/chains/cosmos/genesis.yaml
@@ -112,7 +112,9 @@ spec:
 
               echo "Running setup and config files..."
               bash -e /scripts/setup_genesis.sh
+              {{- if hasKey $chain "genesis" }}
               jq -s '.[0] * .[1]' $CHAIN_DIR/config/genesis.json /patch/genesis.json > $CHAIN_DIR/config/genesis.json.tmp && mv $CHAIN_DIR/config/genesis.json.tmp $CHAIN_DIR/config/genesis.json
+              {{- end }}
               bash -e /scripts/setup_config.sh
           resources: {{- include "devnet.node.resources" ( dict "node" $chain "context" $ ) | trim | nindent 12 }}
           volumeMounts:
@@ -122,8 +124,10 @@ spec:
               name: addresses
             - mountPath: /scripts
               name: scripts
+            {{- if hasKey $chain "genesis" }}
             - mountPath: /patch
               name: patch
+            {{- end }}
       containers:
         - name: validator
           image: {{ $image }}
@@ -256,9 +260,11 @@ spec:
         - name: scripts
           configMap:
             name: setup-scripts
+        {{- if hasKey $chain "genesis" }}
         - name: patch
           configMap:
             name: patch-{{ $chain.name }}
+        {{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/devnet/values.yaml
+++ b/charts/devnet/values.yaml
@@ -111,6 +111,45 @@ chains: []
   #   ports:
   #     rpc: 26659
   #     rest: 1319
+  # - name: osmosis-2
+  #   type: osmosis
+  #   numValidators: 2
+  #   # scripts directive will replace the default scripts with the given scripts
+  #   # please make sure the current scripts are compatible with Starship
+  #   scripts:
+  #     ## createGenesis script will be run before the chain is started
+  #     ## to create the genesis.json file. Can be used to fetch the genesis file too.
+  #     createGenesis:
+  #       file: local/scripts/create-genesis.sh
+  #       data: |- # data is a multiline string injected from --set-file in helm
+  #     ## updateGenesis script will be run on the genesis.json file
+  #     ## run after create-genesis
+  #     updateGenesis:
+  #       file: local/scripts/overwrite-genesis.sh
+  #       data: |- # data is a multiline string injected from --set-file in helm
+  #     updateConfig:
+  #       file: local/scripts/overwrite-config.sh
+  #       data: |- # data is a multiline string injected from --set-file in helm
+  #     ## run as the post-start hook in k8s, to create the validator
+  #     createValidator:
+  #       file: local/scripts/create-validator.sh
+  #       data: |- # data is a multiline string injected from --set-file in helm
+  #     ## transferTokens script will be run to get tokens from the faucet
+  #     transferTokens:
+  #       file: local/scripts/transfer-tokens.sh
+  #       data: |- # data is a multiline string injected from --set-file in helm
+  #     ## buildChain script that can be used for building the chain from source
+  #     buildChain:
+  #       file: local/scripts/build-chain.sh
+  #       data: |- # data is a multiline string injected from --set-file in helm
+  # - name: osmosis-4
+  #   type: osmosis
+  #   numValidators: 2
+  #   # genesis override local to genesis.json
+  #   # this genesis directive is converted to a patch.json file
+  #   # then then `jq -s '.[0] * .[1]' genesis.json patch.json > genesis.json` is run
+  #   genesis:
+  #     auth: ...
 
 # TODO: ability to check the srcConnection and destConnection to use
 relayers: []

--- a/charts/devnet/values.yaml
+++ b/charts/devnet/values.yaml
@@ -111,37 +111,6 @@ chains: []
   #   ports:
   #     rpc: 26659
   #     rest: 1319
-  # - name: osmosis-2
-  #   type: osmosis
-  #   numValidators: 2
-  #   # scripts directive will replace the default scripts with the given scripts
-  #   # please make sure the current scripts are compatible with Starship
-  #   scripts:
-  #     ## createGenesis script will be run before the chain is started
-  #     ## to create the genesis.json file. Can be used to fetch the genesis file too.
-  #     createGenesis:
-  #       file: local/scripts/create-genesis.sh
-  #       data: |- # data is a multiline string injected from --set-file in helm
-  #     ## updateGenesis script will be run on the genesis.json file
-  #     ## run after create-genesis
-  #     updateGenesis:
-  #       file: local/scripts/overwrite-genesis.sh
-  #       data: |- # data is a multiline string injected from --set-file in helm
-  #     updateConfig:
-  #       file: local/scripts/overwrite-config.sh
-  #       data: |- # data is a multiline string injected from --set-file in helm
-  #     ## run as the post-start hook in k8s, to create the validator
-  #     createValidator:
-  #       file: local/scripts/create-validator.sh
-  #       data: |- # data is a multiline string injected from --set-file in helm
-  #     ## transferTokens script will be run to get tokens from the faucet
-  #     transferTokens:
-  #       file: local/scripts/transfer-tokens.sh
-  #       data: |- # data is a multiline string injected from --set-file in helm
-  #     ## buildChain script that can be used for building the chain from source
-  #     buildChain:
-  #       file: local/scripts/build-chain.sh
-  #       data: |- # data is a multiline string injected from --set-file in helm
   # - name: osmosis-4
   #   type: osmosis
   #   numValidators: 2

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -19,13 +19,13 @@ stop: stop-forward delete
 ###############################################################################
 
 install:
-	helm install -f $(HELM_FILE) $(HELM_NAME) ../charts/$(HELM_CHART)
+	helm install -f $(HELM_FILE) $(HELM_NAME) ../../charts/$(HELM_CHART)
 
 upgrade:
-	helm upgrade --debug $(HELM_NAME) ../charts/$(HELM_CHART) -f $(HELM_FILE)
+	helm upgrade --debug $(HELM_NAME) ../../charts/$(HELM_CHART) -f $(HELM_FILE)
 
 debug:
-	helm install --dry-run --debug -f $(HELM_FILE) $(HELM_NAME) ../charts/$(HELM_CHART)
+	helm install --dry-run --debug -f $(HELM_FILE) $(HELM_NAME) ../../charts/$(HELM_CHART)
 
 delete:
 	-helm delete $(HELM_NAME)
@@ -44,7 +44,7 @@ test:
 
 .PHOY: port-forward
 port-forward:
-	$(CURDIR)/../scripts/port-forward.sh --config=$(HELM_FILE)
+	$(CURDIR)/../../scripts/port-forward.sh --config=$(HELM_FILE)
 
 .PHONY: stop-forward
 stop-forward:

--- a/tests/e2e/config.go
+++ b/tests/e2e/config.go
@@ -1,10 +1,11 @@
 package e2e
 
 type Chain struct {
-	Name          string `name:"name" json:"name" yaml:"name"`
-	Type          string `name:"type" json:"type" yaml:"type"`
-	NumValidators int    `name:"num-validators" json:"num_validators" yaml:"numValidators"`
-	Ports         Port   `name:"ports" json:"ports" yaml:"ports"`
+	Name          string                 `name:"name" json:"name" yaml:"name"`
+	Type          string                 `name:"type" json:"type" yaml:"type"`
+	NumValidators int                    `name:"num-validators" json:"num_validators" yaml:"numValidators"`
+	Ports         Port                   `name:"ports" json:"ports" yaml:"ports"`
+	Genesis       map[string]interface{} `name:"genesis" json:"genesis" yaml:"genesis"`
 }
 
 type Port struct {

--- a/tests/e2e/configs/one-chain.yaml
+++ b/tests/e2e/configs/one-chain.yaml
@@ -11,6 +11,16 @@ chains:
       memory: 500M
     faucet:
       concurrency: 2
+    genesis:
+      app_state:
+        staking:
+          params:
+            unbonding_time: "5s"
+        gamm:
+          params:
+            pool_creation_fee:
+              - amount: "500000"
+                denom: uosmo
 
 registry:
   enabled: true


### PR DESCRIPTION
## Overview
Add `genesis` directive that can override the `genesis.json` file after initial creation of the genesis file.

## Implementation
* Specify the `genesis` directive in the config file
* Create a configmap based on the patch, convert yaml to json
* Apply the patch with `jq -s '.[0] * .[1]' genesis.json patch.json`

## Sample
```yaml
chains:
  - name: osmosis-1
    type: osmosis
    numValidators: 1
    genesis:
      app_state:
        staking:
          params:
            unbonding_time: "5s"
        gamm:
          params:
            pool_creation_fee:
              - amount: "500000"
                denom: uosmo
```