### PR TITLE
Concurrency for each gh-action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-build
+  cancel-in-progress: true
+
 jobs:
   build-exposer:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,6 +15,10 @@ on:
       - ".github/workflows/docker.yaml"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-docker
+  cancel-in-progress: true
+
 jobs:
   build-push-types:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -9,14 +9,14 @@ on:
     - cron: '0 18 * * *'
   workflow_dispatch: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-e2e-tests
+  cancel-in-progress: true
+
 jobs:
   e2e-test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
     strategy:
       matrix:

--- a/.github/workflows/lint-check.yaml
+++ b/.github/workflows/lint-check.yaml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-lint
+  cancel-in-progress: true
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-e2e-tests.yaml
+++ b/.github/workflows/pr-e2e-tests.yaml
@@ -6,14 +6,14 @@ on:
       - created
       - edited
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-pr-e2e-tests
+  cancel-in-progress: true
+
 jobs:
   pr-e2e-test:
     runs-on: ubuntu-latest
     if: github.event.issue.pull_request && contains(github.event.comment.body, '/run_e2e')
-
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
 
     strategy:
       matrix:

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-pr-tests
+  cancel-in-progress: true
+
 jobs:
   pr-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -1,10 +1,14 @@
 name: Smoke tests
 
 on:
-  # Run every 2 hours
+  # Run every 6 hours
   schedule:
-    - cron: '0 */2 * * *'
+    - cron: '0 */6 * * *'
   workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-smoke-tests
+  cancel-in-progress: true
 
 jobs:
   smoke-test-1:

--- a/.github/workflows/starship-docker.yaml
+++ b/.github/workflows/starship-docker.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-starship-docker
+  cancel-in-progress: true
+
 jobs:
   deploy-docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add concurrency to each of the workflows, with cancel-in-progress to true.
Too many workflows seem to be running even for the PRs. Reduce the action runner time by fast forwarding cancel.

Note: Sometimes for debuging `cancel-in-progress` might hinder, can be removed tmp per case