### PR TITLE
Support for hermes 1.6.0, `event_source` to pull or push via config

### DIFF
--- a/charts/devnet/defaults.yaml
+++ b/charts/devnet/defaults.yaml
@@ -308,6 +308,9 @@ defaultRelayers:
         enabled: true
         host: "127.0.0.1"
         port: 3001
+      # custom config args
+      event_source:
+        mode: push # allowed values: push, pull. Valid only for 1.6.0+
   go-relayer:
     image: ghcr.io/polymerdao/relayer-ibcx:starship-integration
 

--- a/charts/devnet/templates/_helpers.tpl
+++ b/charts/devnet/templates/_helpers.tpl
@@ -206,3 +206,13 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Given the docker image, returns the tag
+Usage:
+{{ include "image.tag" "username/repo:1.1.0" }}
+*/}}
+{{- define "image.tag" -}}
+{{- $tag := regexFind "[^:]+$" . -}}
+{{ $tag }}
+{{- end -}}

--- a/charts/devnet/templates/relayers/hermes/configmap.yaml
+++ b/charts/devnet/templates/relayers/hermes/configmap.yaml
@@ -4,6 +4,7 @@
 {{ $defaultFile := $.Files.Get "defaults.yaml" | fromYaml }}
 {{ $defaultRelayer := get $defaultFile.defaultRelayers $relayer.type | default dict }}
 {{ $relayer = mergeOverwrite $defaultRelayer $relayer }}
+{{ $tag := include "image.tag" $relayer.image }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -92,7 +93,15 @@ data:
     key_name = "{{ $chain }}"
     rpc_addr = "http://{{ $chain }}-genesis.{{ $.Release.Namespace }}.svc.cluster.local:26657"
     grpc_addr = "http://{{ $chain }}-genesis.{{ $.Release.Namespace }}.svc.cluster.local:9090"
+    {{- if le (semver $tag | (semver "1.6.0").Compare) 0 }}
+    {{- if eq $relayer.config.event_source.mode "pull" }}
+    event_source = { mode = 'pull', interval = '500ms' }
+    {{- else }}
+    event_source = { mode = 'push', url = "ws://{{ $chain }}-genesis.{{ $.Release.Namespace }}.svc.cluster.local:26657/websocket", batch_delay = '500ms' }
+    {{- end }}
+    {{- else }}
     websocket_addr = "ws://{{ $chain }}-genesis.{{ $.Release.Namespace }}.svc.cluster.local:26657/websocket"
+    {{- end }}
     account_prefix = "{{ $fullchain.prefix }}"
     gas_price = { price = 0.25, denom = "{{ $fullchain.denom }}" }
     default_gas = 500000000

--- a/docker/relayers/hermes/versions.yaml
+++ b/docker/relayers/hermes/versions.yaml
@@ -1,4 +1,5 @@
 base: informalsystems/hermes
 versions:
+  - 1.6.0
   - 1.5.1
   - 1.5.0

--- a/docs/pages/config/relayers.mdx
+++ b/docs/pages/config/relayers.mdx
@@ -107,6 +107,11 @@ relayers:
       enabled: false
     telemetry:
       enabled: false
+    ## event_source is a custom configuration, in hermes is set of each of the chains
+    ## one just needs to mention the mode (push or pull), and we do the rest
+    ## For reference: https://github.com/informalsystems/hermes/releases/tag/v1.6.0
+    event_source:
+      mode: "pull" # default is "push"
 ```
 
 All allowed config params can be found in the [default values](https://github.com/cosmology-tech/starship/pull/185/files#diff-b6d755bc9ec9f0229fa0fc7beff17964f31889df81dbd5a16764ed8cdecbfa96R286-R310)

--- a/tests/e2e/configs/two-chain.yaml
+++ b/tests/e2e/configs/two-chain.yaml
@@ -20,7 +20,7 @@ chains:
 relayers:
   - name: osmos-cosmos
     type: hermes
-    image: anmol1696/hermes:1.6.0
+    image: anmol1696/hermes:1.6.0  # todo: replace this with ghcr.io image after merge
     replicas: 1
     chains:
       - osmosis-1

--- a/tests/e2e/configs/two-chain.yaml
+++ b/tests/e2e/configs/two-chain.yaml
@@ -20,6 +20,7 @@ chains:
 relayers:
   - name: osmos-cosmos
     type: hermes
+    image: anmol1696/hermes:1.6.0
     replicas: 1
     chains:
       - osmosis-1
@@ -31,6 +32,8 @@ relayers:
         enabled: false
       telemetry:
         enabled: false
+      event_source:
+        mode: pull
 
 explorer:
   enabled: true


### PR DESCRIPTION
## Overview
* add `event_source` to hermes config to allow pull or push mode (default: push)
* update two-chain e2e test
* set config based on version of hermes from tag

Closes: #153 