### PR TITLE
rc release: 0.1.46-rc2, fix registry service image, add docs

### DIFF
--- a/.github/workflows/starship-docker.yaml
+++ b/.github/workflows/starship-docker.yaml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy-docker-registry:
+  deploy-docker:
     runs-on: ubuntu-latest
 
     permissions:

--- a/charts/devnet/Chart.yaml
+++ b/charts/devnet/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.46-rc1
+version: 0.1.46-rc2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/devnet/values.yaml
+++ b/charts/devnet/values.yaml
@@ -219,9 +219,7 @@ explorer:
 
 registry:
   enabled: false
-  # test image, todo: change this to registry service image
-  image: anmol1696/registry:20230905-7b331fe
-  # image: ghcr.io/cosmology-tech/starship/registry:20230829-eaeeb62
+  image: ghcr.io/cosmology-tech/starship/registry:20230905-b18b37a
   localhost: true
   ports:
     rest: 6060

--- a/docs/pages/config/chains.mdx
+++ b/docs/pages/config/chains.mdx
@@ -101,6 +101,7 @@ chains:
   ports:
     rest: 1317     # Rest endpoint of the Genesis validator node (most used)
     rpc: 26657     # RPC endpoint of the genesis validator node (most used)
+    grpc: 9091     # GRPC endpoint of the genesis validator node (less used)
     faucet: 8001   # Cosmjs faucet running next to the genesis node (most used)
     exposer: 9090  # Exposer sidecar port (less used)
 ```

--- a/docs/pages/config/features.mdx
+++ b/docs/pages/config/features.mdx
@@ -15,6 +15,7 @@ for the infra you spin up.
 ```yaml
 registry:
   enabled: true  # enable registry service
+  localhost: true # default: true, will set chain registry output with api endpoints pointing to localhost, using the chains[].ports for localhost endpoints
   ports:
     rest: 8081   # localhost port for redirecting traffic
   # Optional: resources directive, defualt cpu: 0.2, memory: 200M
@@ -24,6 +25,8 @@ registry:
   # Optional: image directive, default image:ghcr.io/cosmology-tech/starship/registry:20230614-7173db2
   image: ghcr.io/cosmology-tech/starship/registry:20230614-7173db2
 ```
+
+> Note: `registry.localhost` is set to true by default, meaning if the ports are specified in chains[].ports, then we set the various api endpoints of the chain registry to `localhost:<port>`. Make sure `rest`, `grpc`, `rpc` are set as [chain ports](https://starship.cosmology.tech/config/chains#ports). If set to false, then it is set to kubernetes internal DNS endpoints.
 
 ### Usage
 


### PR DESCRIPTION
## Overview
* Release 0.1.46-rc2
* Fix `registry.image` to the latest image from docker
* Add docs for `registry.localhost`