### PR TITLE
Add metrics support to Cosmos chains

### DIFF
--- a/charts/devnet/scripts/update-config.sh
+++ b/charts/devnet/scripts/update-config.sh
@@ -51,6 +51,13 @@ sed -i -e "${line_number}s/enable = false/enable = true/g" $CHAIN_DIR/config/app
 line_number=$(get_next_line_number "Address defines the gRPC server address to bind to." $CHAIN_DIR/config/app.toml)
 sed -i -e "${line_number}s#address = \".*\"#address = \"0.0.0.0:9090\"#g" $CHAIN_DIR/config/app.toml
 
+if [ $METRICS ]; then
+  line_number=$(get_next_line_number "other sinks such as Prometheus." $CHAIN_DIR/config/app.toml)
+  sed -i -e "${line_number}s/enabled = false/enabled = true/g" $CHAIN_DIR/config/app.toml
+
+  line_number=$(get_next_line_number "PrometheusRetentionTime, when positive, enables a Prometheus metrics sink." $CHAIN_DIR/config/app.toml)
+  sed -i -e "${line_number}s/prometheus-retention-time = 0/prometheus-retention-time = 3600/g" $CHAIN_DIR/config/app.toml
+fi
 
 echo "Update consensus params in config.toml"
 sed -i -e "s#timeout_propose = \".*\"#timeout_propose = \"$TIMEOUT_PROPOSE\"#g" $CHAIN_DIR/config/config.toml
@@ -60,5 +67,9 @@ sed -i -e "s#timeout_prevote_delta = \".*\"#timeout_prevote_delta = \"$TIMEOUT_P
 sed -i -e "s#timeout_precommit = \".*\"#timeout_precommit = \"$TIMEOUT_PRECOMMIT\"#g" $CHAIN_DIR/config/config.toml
 sed -i -e "s#timeout_precommit_delta = \".*\"#timeout_precommit_delta = \"$TIMEOUT_PRECOMMIT_DELTA\"#g" $CHAIN_DIR/config/config.toml
 sed -i -e "s#timeout_commit = \".*\"#timeout_commit = \"$TIMEOUT_COMMIT\"#g" $CHAIN_DIR/config/config.toml
+
+if [ $METRICS ]; then
+  sed -i -e "s/prometheus = false/prometheus = true/g" $CHAIN_DIR/config/config.toml
+fi
 
 $CHAIN_BIN tendermint show-node-id

--- a/charts/devnet/scripts/update-config.sh
+++ b/charts/devnet/scripts/update-config.sh
@@ -51,7 +51,7 @@ sed -i -e "${line_number}s/enable = false/enable = true/g" $CHAIN_DIR/config/app
 line_number=$(get_next_line_number "Address defines the gRPC server address to bind to." $CHAIN_DIR/config/app.toml)
 sed -i -e "${line_number}s#address = \".*\"#address = \"0.0.0.0:9090\"#g" $CHAIN_DIR/config/app.toml
 
-if [ $METRICS ]; then
+if [ "$METRICS" == "true" ]; then
   line_number=$(get_next_line_number "other sinks such as Prometheus." $CHAIN_DIR/config/app.toml)
   sed -i -e "${line_number}s/enabled = false/enabled = true/g" $CHAIN_DIR/config/app.toml
 
@@ -68,7 +68,7 @@ sed -i -e "s#timeout_precommit = \".*\"#timeout_precommit = \"$TIMEOUT_PRECOMMIT
 sed -i -e "s#timeout_precommit_delta = \".*\"#timeout_precommit_delta = \"$TIMEOUT_PRECOMMIT_DELTA\"#g" $CHAIN_DIR/config/config.toml
 sed -i -e "s#timeout_commit = \".*\"#timeout_commit = \"$TIMEOUT_COMMIT\"#g" $CHAIN_DIR/config/config.toml
 
-if [ $METRICS ]; then
+if [ "$METRICS" == "true" ]; then
   sed -i -e "s/prometheus = false/prometheus = true/g" $CHAIN_DIR/config/config.toml
 fi
 

--- a/charts/devnet/templates/chains/cosmos/genesis.yaml
+++ b/charts/devnet/templates/chains/cosmos/genesis.yaml
@@ -114,9 +114,35 @@ spec:
                 exit 0
               fi
 
-              echo "Running setup and config files..."
+              echo "Running setup genesis script..."
               bash -e /scripts/create-genesis.sh
               bash -e /scripts/update-genesis.sh
+          resources: {{- include "devnet.node.resources" ( dict "node" $chain "context" $ ) | trim | nindent 12 }}
+          volumeMounts:
+            - mountPath: {{ $chain.home }}
+              name: node
+            - mountPath: /configs
+              name: addresses
+            - mountPath: /scripts
+              name: scripts
+        - name: init-config
+          image: {{ $image }}
+          imagePullPolicy: Always
+          env:
+            {{- include "devnet.defaultEvnVars" $chain | indent 12 }}
+            {{- include "devnet.evnVars" $chain | indent 12 }}
+            {{- include "devnet.timeoutVars" $.Values | indent 12 }}
+            - name: KEYS_CONFIG
+              value: /configs/keys.json
+          command:
+            - bash
+            - "-c"
+            - |
+              VAL_INDEX=${HOSTNAME##*-}
+              echo "Validator Index: $VAL_INDEX"
+
+              echo "Running setup config script..."
+              export METRICS={{ $chain.metrics }}
               {{- if hasKey $chain "genesis" }}
               jq -s '.[0] * .[1]' $CHAIN_DIR/config/genesis.json /patch/genesis.json > $CHAIN_DIR/config/genesis.json.tmp && mv $CHAIN_DIR/config/genesis.json.tmp $CHAIN_DIR/config/genesis.json
               {{- end }}

--- a/charts/devnet/templates/chains/cosmos/genesis.yaml
+++ b/charts/devnet/templates/chains/cosmos/genesis.yaml
@@ -134,6 +134,8 @@ spec:
             {{- include "devnet.timeoutVars" $.Values | indent 12 }}
             - name: KEYS_CONFIG
               value: /configs/keys.json
+            - name: METRICS
+              value: {{ $chain.metrics }}
           command:
             - bash
             - "-c"
@@ -142,7 +144,6 @@ spec:
               echo "Validator Index: $VAL_INDEX"
 
               echo "Running setup config script..."
-              export METRICS={{ $chain.metrics }}
               {{- if hasKey $chain "genesis" }}
               jq -s '.[0] * .[1]' $CHAIN_DIR/config/genesis.json /patch/genesis.json > $CHAIN_DIR/config/genesis.json.tmp && mv $CHAIN_DIR/config/genesis.json.tmp $CHAIN_DIR/config/genesis.json
               {{- end }}

--- a/charts/devnet/templates/chains/cosmos/genesis.yaml
+++ b/charts/devnet/templates/chains/cosmos/genesis.yaml
@@ -135,7 +135,7 @@ spec:
             - name: KEYS_CONFIG
               value: /configs/keys.json
             - name: METRICS
-              value: {{ $chain.metrics }}
+              value: "{{ $chain.metrics }}"
           command:
             - bash
             - "-c"

--- a/charts/devnet/templates/chains/cosmos/validator.yaml
+++ b/charts/devnet/templates/chains/cosmos/validator.yaml
@@ -131,16 +131,43 @@ spec:
               curl http://$GENESIS_HOST.$NAMESPACE.svc.cluster.local:$GENESIS_PORT/genesis -o $CHAIN_DIR/config/genesis.json
               echo "Genesis file that we got....."
               cat $CHAIN_DIR/config/genesis.json
+          resources: {{- include "devnet.node.resources" ( dict "node" $chain "context" $ ) | trim | nindent 12 }}
+          volumeMounts:
+            - mountPath: {{ $chain.home }}
+              name: node
+            - mountPath: /configs
+              name: addresses
+            - mountPath: /scripts
+              name: scripts
+        - name: init-config
+          image: {{ $image }}
+          imagePullPolicy: Always
+          env:
+            {{- include "devnet.defaultEvnVars" $chain | indent 12 }}
+            {{- include "devnet.evnVars" $chain | indent 12 }}
+            {{- include "devnet.timeoutVars" $.Values | indent 12 }}
+            {{- include "devnet.genesisVars" $dataExposer | indent 12 }}
+            - name: KEYS_CONFIG
+              value: /configs/keys.json
+            - name: METRICS
+              value: "{{ $chain.metrics }}"
+          command:
+            - bash
+            - "-c"
+            - |
+              VAL_INDEX=${HOSTNAME##*-}
+              echo "Validator Index: $VAL_INDEX"
 
-              echo "Setup config files"
+              echo "Running setup config script..."
               bash -e /scripts/update-config.sh
-
+              
               curl -s http://$GENESIS_HOST.$NAMESPACE.svc.cluster.local:$GENESIS_PORT/node_id
               NODE_ID=$(curl -s http://$GENESIS_HOST.$NAMESPACE.svc.cluster.local:$GENESIS_PORT/node_id | jq -r ".node_id")
               if [[ $NODE_ID == "" ]]; then
                 echo "Node ID is null, exiting early"
                 exit 1
               fi
+              
               GENESIS_NODE_P2P=$NODE_ID@$GENESIS_HOST.$NAMESPACE.svc.cluster.local:26656
               echo "Node P2P: $GENESIS_NODE_P2P"
               sed -i "s/persistent_peers = \"\"/persistent_peers = \"$GENESIS_NODE_P2P\"/g" $CHAIN_DIR/config/config.toml

--- a/charts/devnet/templates/chains/cosmos/validator.yaml
+++ b/charts/devnet/templates/chains/cosmos/validator.yaml
@@ -96,6 +96,8 @@ spec:
             {{- include "devnet.genesisVars" $dataExposer | indent 12 }}
             - name: KEYS_CONFIG
               value: /configs/keys.json
+            - name: METRICS
+              value: "{{ $chain.metrics }}"
           command:
             - bash
             - "-c"

--- a/charts/devnet/values.schema.json
+++ b/charts/devnet/values.schema.json
@@ -167,6 +167,9 @@
           "coinType": {
             "type": "number"
           },
+          "metrics": {
+            "type": "boolean"
+          },
           "repo": {
             "type": "string"
           },

--- a/tests/e2e/configs/one-chain.yaml
+++ b/tests/e2e/configs/one-chain.yaml
@@ -2,6 +2,7 @@ chains:
   - name: osmosis-1
     type: osmosis
     numValidators: 1
+    metrics: true
     ports:
       rest: 1313
       rpc: 26653

--- a/tests/e2e/configs/scripts/update-custom-config.sh
+++ b/tests/e2e/configs/scripts/update-custom-config.sh
@@ -48,6 +48,13 @@ sed -i -e "${line_number}s/enable = false/enable = true/g" $CHAIN_DIR/config/app
 line_number=$(get_next_line_number "Address defines the gRPC server address to bind to." $CHAIN_DIR/config/app.toml)
 sed -i -e "${line_number}s#address = \".*\"#address = \"0.0.0.0:9090\"#g" $CHAIN_DIR/config/app.toml
 
+if [ $METRICS ]; then
+  line_number=$(get_next_line_number "other sinks such as Prometheus." $CHAIN_DIR/config/app.toml)
+  sed -i -e "${line_number}s/enabled = false/enabled = true/g" $CHAIN_DIR/config/app.toml
+
+  line_number=$(get_next_line_number "PrometheusRetentionTime, when positive, enables a Prometheus metrics sink." $CHAIN_DIR/config/app.toml)
+  sed -i -e "${line_number}s/prometheus-retention-time = 0/prometheus-retention-time = 3600/g" $CHAIN_DIR/config/app.toml
+fi
 
 echo "Update consensus params in config.toml"
 sed -i -e "s#timeout_propose = \".*\"#timeout_propose = \"$TIMEOUT_PROPOSE\"#g" $CHAIN_DIR/config/config.toml
@@ -57,5 +64,9 @@ sed -i -e "s#timeout_prevote_delta = \".*\"#timeout_prevote_delta = \"$TIMEOUT_P
 sed -i -e "s#timeout_precommit = \".*\"#timeout_precommit = \"$TIMEOUT_PRECOMMIT\"#g" $CHAIN_DIR/config/config.toml
 sed -i -e "s#timeout_precommit_delta = \".*\"#timeout_precommit_delta = \"$TIMEOUT_PRECOMMIT_DELTA\"#g" $CHAIN_DIR/config/config.toml
 sed -i -e "s#timeout_commit = \".*\"#timeout_commit = \"$TIMEOUT_COMMIT\"#g" $CHAIN_DIR/config/config.toml
+
+if [ $METRICS ]; then
+  sed -i -e "s/prometheus = false/prometheus = true/g" $CHAIN_DIR/config/config.toml
+fi
 
 $CHAIN_BIN tendermint show-node-id

--- a/tests/e2e/configs/scripts/update-custom-config.sh
+++ b/tests/e2e/configs/scripts/update-custom-config.sh
@@ -48,7 +48,7 @@ sed -i -e "${line_number}s/enable = false/enable = true/g" $CHAIN_DIR/config/app
 line_number=$(get_next_line_number "Address defines the gRPC server address to bind to." $CHAIN_DIR/config/app.toml)
 sed -i -e "${line_number}s#address = \".*\"#address = \"0.0.0.0:9090\"#g" $CHAIN_DIR/config/app.toml
 
-if [ $METRICS ]; then
+if [ "$METRICS" == "true" ]; then
   line_number=$(get_next_line_number "other sinks such as Prometheus." $CHAIN_DIR/config/app.toml)
   sed -i -e "${line_number}s/enabled = false/enabled = true/g" $CHAIN_DIR/config/app.toml
 
@@ -65,7 +65,7 @@ sed -i -e "s#timeout_precommit = \".*\"#timeout_precommit = \"$TIMEOUT_PRECOMMIT
 sed -i -e "s#timeout_precommit_delta = \".*\"#timeout_precommit_delta = \"$TIMEOUT_PRECOMMIT_DELTA\"#g" $CHAIN_DIR/config/config.toml
 sed -i -e "s#timeout_commit = \".*\"#timeout_commit = \"$TIMEOUT_COMMIT\"#g" $CHAIN_DIR/config/config.toml
 
-if [ $METRICS ]; then
+if [ "$METRICS" == "true" ]; then
   sed -i -e "s/prometheus = false/prometheus = true/g" $CHAIN_DIR/config/config.toml
 fi
 


### PR DESCRIPTION
To be able to use Starship in production, it needs to have controls to enable metrics supported by Cosmos chains.

Additionally, split genesis and config generation into separate steps.