### PR TITLE
chore: add conditions to not run PRs on draft PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, reopened, synchronize, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-build
@@ -14,6 +15,7 @@ concurrency:
 
 jobs:
   build-exposer:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
 
     steps:
@@ -30,6 +32,7 @@ jobs:
           cd exposer && make build
 
   build-registry:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
 
     steps:
@@ -46,6 +49,7 @@ jobs:
           cd registry && make build
 
   build-faucet:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -13,6 +13,7 @@ on:
     paths:
       - "docker/**"
       - ".github/workflows/docker.yaml"
+    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 
 concurrency:
@@ -21,6 +22,7 @@ concurrency:
 
 jobs:
   build-push-types:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
 
     permissions:
@@ -68,6 +70,7 @@ jobs:
           ./scripts/build-docker.sh --type ${{ matrix.build-type }} --process all --version all --push --force
 
   build-push-chains:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,9 +13,11 @@ on:
     paths:
       - "docs/**"
       - ".github/workflows/docs.yaml"
+    types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
   deploy:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/lint-check.yaml
+++ b/.github/workflows/lint-check.yaml
@@ -1,12 +1,13 @@
 name: Lint and Test Charts
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+    types: [ opened, reopened, synchronize, ready_for_review ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-lint
@@ -14,6 +15,7 @@ concurrency:
 
 jobs:
   lint-test:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, reopened, synchronize, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-pr-tests
@@ -11,6 +12,7 @@ concurrency:
 
 jobs:
   pr-test:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
## Overview
Do not run gh-actions on PRs in draft. Needed to make it explicit.