### PR TITLE
feature: `ingress` directive in config file

### DIFF
--- a/charts/devnet/Chart.yaml
+++ b/charts/devnet/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.48-rc1
+version: 0.1.48-rc2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/devnet/templates/_helpers.tpl
+++ b/charts/devnet/templates/_helpers.tpl
@@ -185,6 +185,8 @@ Returns a comma seperated list of urls for the RPC address
 {{- range $chain := .Values.chains -}}
   {{- if and ($localhost) (($chain.ports).rpc) -}}
   {{- $values = printf "http://localhost:%v" $chain.ports.rpc | append $values -}}
+  {{- else if $.Values.ingress.enabled }}
+  {{- $values = printf "https://rpc.%s-genesis.%s" $chain.name ($.Values.ingress.host | replace "*." "") }}
   {{- else -}}
   {{- $host := include "devnet.chain.name" $chain.name }}
   {{- $values = printf "http://%s-genesis.$(NAMESPACE).svc.cluster.local:26657" $host | append $values -}}
@@ -203,6 +205,8 @@ If registry.localhost is set to true, then use $chain ports
 {{- range $chain := .Values.chains -}}
   {{- if and ($localhost) (($chain.ports).grpc) -}}
   {{- $values = printf "http://localhost:%v" $chain.ports.grpc | append $values -}}
+  {{- else if $.Values.ingress.enabled }}
+  {{- $values = printf "https://grpc.%s-genesis.%s" $chain.name ($.Values.ingress.host | replace "*." "") }}
   {{- else -}}
   {{- $host := include "devnet.chain.name" $chain.name }}
   {{- $values = printf "http://%s-genesis.$(NAMESPACE).svc.cluster.local:9091" $host | append $values -}}
@@ -221,6 +225,8 @@ If registry.localhost is set to true, then use $chain ports
 {{- range $chain := .Values.chains -}}
   {{- if and ($localhost) (($chain.ports).rest) -}}
   {{- $values = printf "http://localhost:%v" $chain.ports.rest | append $values -}}
+  {{- else if $.Values.ingress.enabled }}
+  {{- $values = printf "https://rest.%s-genesis.%s" $chain.name ($.Values.ingress.host | replace "*." "") }}
   {{- else -}}
   {{- $host := include "devnet.chain.name" $chain.name }}
   {{- $values = printf "http://%s-genesis.$(NAMESPACE).svc.cluster.local:1317" $host | append $values -}}

--- a/charts/devnet/templates/explorer.yaml
+++ b/charts/devnet/templates/explorer.yaml
@@ -87,11 +87,19 @@ data:
     {
       "chain_name": "{{ $chain.name }}",
       "coingecko": "{{ $chain.type }}",
+      {{- if $.Values.ingress.enabled }}
+      "api": "https://rest.{{ $chain.name }}-genesis.{{ $.Values.ingress.host | replace "*." "" }}:443",
+      "rpc": [
+        "https://rpc.{{ $chain.name }}-genesis.{{ $.Values.ingress.host | replace "*." "" }}:443",
+        "https://rpc.{{ $chain.name }}-genesis.{{ $.Values.ingress.host | replace "*." "" }}:443"
+      ],
+      {{- else }}
       "api": "http://{{ $host }}:{{ $chain.ports.rest }}",
       "rpc": [
         "http://{{ $host }}:{{ $chain.ports.rpc }}",
         "http://{{ $host }}:{{ $chain.ports.rpc }}"
       ],
+      {{- end }}
       "snapshot_provider": "",
       "sdk_version": "0.45.6",
       "coin_type": "{{ $chain.coinType }}",

--- a/charts/devnet/templates/ingress/cert-issuer.yaml
+++ b/charts/devnet/templates/ingress/cert-issuer.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.ingress.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Values.ingress.certManager.issuer }}
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: devops@cosmoslogy.zone
+    privateKeySecretRef:
+      name: {{ .Values.ingress.certManager.issuer }}
+    solvers:
+      ## todo: move to DNS01 solver for wildcard dns
+      ## https://stackoverflow.com/questions/66051624/generate-wildcard-certificate-on-kubernetes-cluster-with-digitalocean-for-my-ngi
+      - http01:
+          ingress:
+            class: {{ .Values.ingress.type }}
+---
+{{- end }}

--- a/charts/devnet/templates/ingress/ingress.yaml
+++ b/charts/devnet/templates/ingress/ingress.yaml
@@ -1,0 +1,97 @@
+{{- if .Values.ingress.enabled }}
+{{ $host := $.Values.ingress.host | replace "*." "" }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.ingress.type }}-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    cert-manager.io/issuer: "{{ .Values.ingress.certManager.issuer }}"
+spec:
+  ingressClassName: {{ .Values.ingress.type }}
+  tls:
+    ## todo: use DNS01 issuer for wildcard certs, else this list will keep growing with number of validators and chains
+    ## https://stackoverflow.com/questions/66051624/generate-wildcard-certificate-on-kubernetes-cluster-with-digitalocean-for-my-ngi
+    {{- if .Values.explorer.enabled }}
+    - hosts:
+        - "explorer.{{ $host }}"
+      secretName: explorer.{{ .Values.ingress.type }}-ingress-tls
+    {{- end }}
+    {{- if .Values.registry.enabled }}
+    - hosts:
+        - "registry.{{ $host }}"
+      secretName: registry.{{ .Values.ingress.type }}-ingress-tls
+    {{- end }}
+    {{- range $chain := .Values.chains }}
+    - hosts:
+        - "rest.{{ $chain.name }}-genesis.{{ $host }}"
+      secretName: rest.{{ $chain.name }}-genesis.{{ .Values.ingress.type }}-ingress-tls
+    - hosts:
+        - "rpc.{{ $chain.name }}-genesis.{{ $host }}"
+      secretName: rpc.{{ $chain.name }}-genesis.{{ .Values.ingress.type }}-ingress-tls
+    {{- end }}
+  rules:
+    {{- if .Values.explorer.enabled }}
+    - host: "explorer.{{ $host }}"
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            path: "/(.*)"
+            backend:
+              service:
+                name: explorer
+                port:
+                  name: http
+    {{- end }}
+    {{- if .Values.registry.enabled }}
+    - host: "registry.{{ $host }}"
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            path: "/(.*)"
+            backend:
+              service:
+                name: registry
+                port:
+                  name: http
+    {{- end }}
+    {{- range $chain := .Values.chains }}
+    - host: "rest.{{ $chain.name }}-genesis.{{ $host }}"
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            path: "/(.*)"
+            backend:
+              service:
+                name: {{ $chain.name }}-genesis
+                port:
+                  name: rest
+          - pathType: ImplementationSpecific
+            path: "/faucet/(.*)"
+            backend:
+              service:
+                name: {{ $chain.name }}-genesis
+                port:
+                  name: faucet
+          - pathType: ImplementationSpecific
+            path: "/exposer/(.*)"
+            backend:
+              service:
+                name: {{ $chain.name }}-genesis
+                port:
+                  name: exposer
+    - host: "rpc.{{ $chain.name }}-genesis.{{ $host }}"
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            path: "/(.*)"
+            backend:
+              service:
+                name: {{ $chain.name }}-genesis
+                port:
+                  name: rpc
+    {{- end }}
+---
+{{- end }}

--- a/charts/devnet/templates/ingress/ingress.yaml
+++ b/charts/devnet/templates/ingress/ingress.yaml
@@ -113,5 +113,6 @@ spec:
                 port:
                   name: exposer
     {{- end }}
+    {{- end }}
 ---
 {{- end }}

--- a/charts/devnet/templates/ingress/ingress.yaml
+++ b/charts/devnet/templates/ingress/ingress.yaml
@@ -93,5 +93,25 @@ spec:
                 port:
                   name: rpc
     {{- end }}
+    {{- range $relayer := .Values.relayers }}
+    {{- if eq $relayer.type "hermes" }}
+    - host: "rest.{{ $relayer.type }}-{{ $relayer.name }}.{{ $host }}"
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            path: "/(.*)"
+            backend:
+              service:
+                name: {{ $relayer.type }}-{{ $relayer.name }}
+                port:
+                  name: rest
+          - pathType: ImplementationSpecific
+            path: "/exposer/(.*)"
+            backend:
+              service:
+                name: {{ $relayer.type }}-{{ $relayer.name }}
+                port:
+                  name: exposer
+    {{- end }}
 ---
 {{- end }}

--- a/charts/devnet/values.schema.json
+++ b/charts/devnet/values.schema.json
@@ -644,6 +644,36 @@
         "enabled"
       ]
     },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "nginx"
+          ]
+        },
+        "host": {
+          "type": "string"
+        },
+        "certManager": {
+          "type": "object",
+          "properties": {
+            "issuer": {
+              "type": "string"
+            }
+          }
+        },
+        "resources": { "$ref":  "#/$def/resources" }
+      },
+      "additionalProperties": false,
+      "required": [
+        "enabled"
+      ]
+    },
     "images": {
       "type": "object",
       "properties": {

--- a/charts/devnet/values.yaml
+++ b/charts/devnet/values.yaml
@@ -241,3 +241,12 @@ monitoring:
   resources:
     cpu: "0.2"
     memory: "400M"
+
+ingress:
+  enabled: false
+  type: nginx
+  # host must be a wildcard entry, so that we can use the wildcard to create
+  # service specific ingress rules
+  host: "*.thestarship.io"
+  certManager:
+    issuer: "cert-issuer"


### PR DESCRIPTION
Closes: #8 

Note: This presumes that both the controller for `ingress` and `cert-issuer` are pre-installed. 
Maybe we need to figure out a way to install them with the helm chart itself