### PR TITLE
chore: rename cosmos to cosmoshub

### DIFF
--- a/docs/pages/config/chains.mdx
+++ b/docs/pages/config/chains.mdx
@@ -22,7 +22,7 @@ chains:
   name: osmosis
   ...
 - id: gaia-2
-  name: cosmos
+  name: cosmoshub
   ...
 ```
 
@@ -285,7 +285,7 @@ Enabling cometmock is really simple with following
 ```yaml
 chains:
 - id: cosmoshub-4
-  name: cosmos
+  name: cosmoshub
   numValidators: 4
   cometmock:
     enabled: true

--- a/docs/pages/config/index.mdx
+++ b/docs/pages/config/index.mdx
@@ -19,7 +19,7 @@ chains:
       rest: 1313
       rpc: 26653
   - id: gaia-1
-    name: cosmos
+    name: cosmoshub
     numValidators: 2
     ports:
       rest: 1317

--- a/docs/pages/get-started/step-3.mdx
+++ b/docs/pages/get-started/step-3.mdx
@@ -42,7 +42,7 @@ chains:
       rest: 1313
       rpc: 26653
   - id: gaia-1
-    name: cosmos
+    name: cosmoshub
     numValidators: 1
     ports:
       rest: 1317

--- a/starship/charts/devnet/defaults.yaml
+++ b/starship/charts/devnet/defaults.yaml
@@ -81,7 +81,7 @@ defaultChains:
     hdPath: m/44'/118'/0'/0/0
     coinType: 118
     repo: https://github.com/CosmWasm/wasmd
-  cosmos:
+  cosmoshub:
     image: ghcr.io/cosmology-tech/starship/gaia:v14.1.0
     home: /root/.gaia
     binary: gaiad

--- a/starship/charts/devnet/values.schema.json
+++ b/starship/charts/devnet/values.schema.json
@@ -113,7 +113,7 @@
             "enum": [
               "custom",
               "osmosis",
-              "cosmos",
+              "cosmoshub",
               "juno",
               "stride",
               "ics",

--- a/starship/tests/e2e/configs/agoric.yaml
+++ b/starship/tests/e2e/configs/agoric.yaml
@@ -14,7 +14,7 @@ chains:
       cpu: 1
       memory: 2Gi
   - id: cosmoshub-4
-    name: cosmos
+    name: cosmoshub
     image: ghcr.io/cosmology-tech/starship/gaia:v10.0.1
     numValidators: 1
     ports:

--- a/starship/tests/e2e/configs/build-chain.yaml
+++ b/starship/tests/e2e/configs/build-chain.yaml
@@ -1,6 +1,6 @@
 chains:
   - id: cosmoshub-4
-    name: cosmos
+    name: cosmoshub
     numValidators: 2
     ports:
       rest: 1317

--- a/starship/tests/e2e/configs/evmos.yaml
+++ b/starship/tests/e2e/configs/evmos.yaml
@@ -8,7 +8,7 @@ chains:
       rpc: 26653
       exposer: 38083
   - id: cosmoshub-4
-    name: cosmos
+    name: cosmoshub
     image: ghcr.io/cosmology-tech/starship/gaia:v10.0.1
     numValidators: 1
     ports:

--- a/starship/tests/e2e/configs/injective.yaml
+++ b/starship/tests/e2e/configs/injective.yaml
@@ -7,7 +7,7 @@ chains:
       rpc: 26653
       exposer: 38083
   - id: cosmoshub-4
-    name: cosmos
+    name: cosmoshub
     numValidators: 1
     ports:
       rest: 1317

--- a/starship/tests/e2e/configs/multi-relayer.yaml
+++ b/starship/tests/e2e/configs/multi-relayer.yaml
@@ -9,7 +9,7 @@ chains:
       rpc: 26653
       exposer: 38083
   - id: cosmoshub-4
-    name: cosmos
+    name: cosmoshub
     image: ghcr.io/cosmology-tech/starship/gaia:v10.0.1
     numValidators: 1
     faucet:

--- a/starship/tests/e2e/configs/neutron.yaml
+++ b/starship/tests/e2e/configs/neutron.yaml
@@ -11,7 +11,7 @@ chains:
       rpc: 26653
       exposer: 38083
   - id: cosmoshub-4
-    name: cosmos
+    name: cosmoshub
     numValidators: 2
     ports:
       rest: 1317

--- a/starship/tests/e2e/configs/one-chain-cometmock.yaml
+++ b/starship/tests/e2e/configs/one-chain-cometmock.yaml
@@ -1,6 +1,6 @@
 chains:
   - id: cosmoshub-4
-    name: cosmos
+    name: cosmoshub
     numValidators: 1
     ports:
       rpc: 26653

--- a/starship/tests/e2e/configs/three-chain.yaml
+++ b/starship/tests/e2e/configs/three-chain.yaml
@@ -9,7 +9,7 @@ chains:
       rpc: 26653
       exposer: 38083
   - id: cosmoshub-4
-    name: cosmos
+    name: cosmoshub
     image: ghcr.io/cosmology-tech/starship/gaia:v10.0.1
     numValidators: 1
     faucet:

--- a/starship/tests/e2e/configs/two-chain-cometmock.yaml
+++ b/starship/tests/e2e/configs/two-chain-cometmock.yaml
@@ -11,7 +11,7 @@ chains:
       rpc: 26653
       exposer: 38083
   - id: cosmoshub-4
-    name: cosmos
+    name: cosmoshub
     numValidators: 2
     faucet:
       enabled: false

--- a/starship/tests/e2e/configs/two-chain-gorelayer.yaml
+++ b/starship/tests/e2e/configs/two-chain-gorelayer.yaml
@@ -8,7 +8,7 @@ chains:
       exposer: 38083
       faucet: 8001
   - id: cosmoshub-4
-    name: cosmos
+    name: cosmoshub
     numValidators: 2
     ports:
       rest: 1317

--- a/starship/tests/e2e/configs/two-chain-monitoring.yaml
+++ b/starship/tests/e2e/configs/two-chain-monitoring.yaml
@@ -11,7 +11,7 @@ chains:
       exposer: 38083
       faucet: 8001
   - id: cosmoshub-4
-    name: cosmos
+    name: cosmoshub
     image: ghcr.io/cosmology-tech/starship/gaia:v10.0.1
     numValidators: 2
     metrics: true

--- a/starship/tests/e2e/configs/two-chain.yaml
+++ b/starship/tests/e2e/configs/two-chain.yaml
@@ -8,7 +8,7 @@ chains:
       exposer: 38083
       faucet: 8001
   - id: cosmoshub-4
-    name: cosmos
+    name: cosmoshub
     numValidators: 2
     faucet:
       enabled: false

--- a/starship/tests/smoke/ci/osmojs.yaml
+++ b/starship/tests/smoke/ci/osmojs.yaml
@@ -11,7 +11,7 @@ chains:
       cpu: "0.2"
       memory: "200M"
   - id: cosmos-2
-    name: cosmos
+    name: cosmoshub
     numValidators: 1
     ports:
       rest: 1313


### PR DESCRIPTION
## Overview
In starship we had named cosmoshub chain as cosmos. To match the standards followed in chain-registry, we are changing it to cosmoshub.

## Note
Will be part of the next chart release and only v2. 