### PR TITLE
feat: add chain directive for `env`

### DIFF
--- a/docs/pages/config/chains.mdx
+++ b/docs/pages/config/chains.mdx
@@ -299,6 +299,20 @@ Noteable other versions are: `v0.34.x` as well as `v0.38.x`.
 If `cometmock` is enabled, during port-forwarding, we forward the `ports.rpc` to the cometmock endpoint.
 For in-cluster communication, make sure to connect to the cometmock service instead of validator service for rpc connections.
 
+## `env` (optional)
+The `env` directive allows you to set custom environment variables for the validator and genesis containers. This can be useful for enabling features like debug logging or configuring specific settings.
+
+The `env` directive expects an array of objects, each containing a `name` and `value` field. Here's an example of how to use the `env` directive:
+```yaml
+chains:
+- id: agoriclocal
+  name: agoric
+  numValidators: 1
+  env:
+    - name: DEBUG
+      value: SwingSet:vat,SwingSet:ls
+```
+
 ### Learn more
 To more about CometMock, have a look at the [blog](https://informal.systems/blog/cometmock) that explains its working
 

--- a/starship/charts/devnet/templates/chains/cosmos/genesis.yaml
+++ b/starship/charts/devnet/templates/chains/cosmos/genesis.yaml
@@ -183,6 +183,10 @@ spec:
               value: "{{ $chain.faucet.enabled }}"
             - name: SLOGFILE
               value: "slog.slog"
+            {{- range $env := $chain.env }}
+            - name: {{ $env.name }}
+              value: {{ $env.value | quote }}
+            {{- end }}
           command:
             - bash
             - "-c"

--- a/starship/charts/devnet/templates/chains/cosmos/validator.yaml
+++ b/starship/charts/devnet/templates/chains/cosmos/validator.yaml
@@ -185,6 +185,10 @@ spec:
               value: /configs/keys.json
             - name: SLOGFILE
               value: "slog.slog"
+            {{- range $env := $chain.env }}
+            - name: {{ $env.name }}
+              value: {{ $env.value | quote }}
+            {{- end }}
           command:
             - bash
             - "-c"

--- a/starship/charts/devnet/values.schema.json
+++ b/starship/charts/devnet/values.schema.json
@@ -463,6 +463,21 @@
             },
             "additionalProperties": false
           },
+          "env": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
+              },
+              "required": ["name", "value"]
+            }
+          },
           "resources": { "$ref":  "#/$def/resources" },
           "cometmock": {
             "type": "object",

--- a/starship/charts/devnet/values.yaml
+++ b/starship/charts/devnet/values.yaml
@@ -144,6 +144,10 @@ chains: []
   #     buildChain:
   #       file: local/scripts/build-chain.sh
   #       data: |- # data is a multiline string injected from --set-file in helm
+  #   # set custom environment variables for the `validator` container
+  #   env:
+  #     - name: DEBUG
+  #       value: true
 
 # TODO: ability to check the srcConnection and destConnection to use
 relayers: []


### PR DESCRIPTION
- adds `env` to chain directive syntax to support custom environment variables in the `genesis` and `validator` containers
