### PR TITLE
fix: respect custom registry and explorer ports

### DIFF
--- a/examples/cosmos-simapp-multi/scripts/port-forward.sh
+++ b/examples/cosmos-simapp-multi/scripts/port-forward.sh
@@ -68,17 +68,21 @@ done
 
 echo "Port forward services"
 
-if [[ $(yq -r ".registry.enabled" $CONFIGFILE) == "true" ]];
-then
-  kubectl port-forward service/registry 8081:$REGISTRY_LCD_PORT > /dev/null 2>&1 &
-  kubectl port-forward service/registry 9091:$REGISTRY_GRPC_PORT > /dev/null 2>&1 &
+if [[ $(yq -r ".registry.enabled" $CONFIGFILE) == "true" ]]; then
+  registry_lcd_port=$(yq -r ".registry.ports.rest" $CONFIGFILE)
+  registry_grpc_port=$(yq -r ".registry.ports.grpc" $CONFIGFILE)
+  registry_lcd_port=${registry_lcd_port:-$REGISTRY_LCD_PORT}
+  registry_grpc_port=${registry_grpc_port:-$REGISTRY_GRPC_PORT}
+  kubectl port-forward service/registry ${registry_lcd_port}:$REGISTRY_LCD_PORT > /dev/null 2>&1 &
+  kubectl port-forward service/registry ${registry_grpc_port}:$REGISTRY_GRPC_PORT > /dev/null 2>&1 &
   sleep 1
-  color yellow "registry: forwarded registry lcd to grpc http://localhost:8081, to http://localhost:9091"
+  color yellow "registry: forwarded registry lcd to http://localhost:${registry_lcd_port}, grpc to http://localhost:${registry_grpc_port}"
 fi
 
-if [[ $(yq -r ".explorer.enabled" $CONFIGFILE) == "true" ]];
-then
-  kubectl port-forward service/explorer 8080:$EXPLORER_LCD_PORT > /dev/null 2>&1 &
+if [[ $(yq -r ".explorer.enabled" $CONFIGFILE) == "true" ]]; then
+  explorer_port=$(yq -r ".explorer.ports.rest" $CONFIGFILE)
+  explorer_port=${explorer_port:-$EXPLORER_LCD_PORT}
+  kubectl port-forward service/explorer ${explorer_port}:$EXPLORER_LCD_PORT > /dev/null 2>&1 &
   sleep 1
-  color green "Open the explorer to get started.... http://localhost:8080"
+  color green "Open the explorer to get started.... http://localhost:${explorer_port}"
 fi

--- a/examples/getting-started/scripts/port-forward.sh
+++ b/examples/getting-started/scripts/port-forward.sh
@@ -74,17 +74,21 @@ done
 
 echo "Port forward services"
 
-if [[ $(yq -r ".registry.enabled" $CONFIGFILE) == "true" ]];
-then
-  kubectl port-forward service/registry 8081:$REGISTRY_LCD_PORT > /dev/null 2>&1 &
-  kubectl port-forward service/registry 9091:$REGISTRY_GRPC_PORT > /dev/null 2>&1 &
+if [[ $(yq -r ".registry.enabled" $CONFIGFILE) == "true" ]]; then
+  registry_lcd_port=$(yq -r ".registry.ports.rest" $CONFIGFILE)
+  registry_grpc_port=$(yq -r ".registry.ports.grpc" $CONFIGFILE)
+  registry_lcd_port=${registry_lcd_port:-$REGISTRY_LCD_PORT}
+  registry_grpc_port=${registry_grpc_port:-$REGISTRY_GRPC_PORT}
+  kubectl port-forward service/registry ${registry_lcd_port}:$REGISTRY_LCD_PORT > /dev/null 2>&1 &
+  kubectl port-forward service/registry ${registry_grpc_port}:$REGISTRY_GRPC_PORT > /dev/null 2>&1 &
   sleep 1
-  color yellow "registry: forwarded registry lcd to grpc http://localhost:8081, to http://localhost:9091"
+  color yellow "registry: forwarded registry lcd to http://localhost:${registry_lcd_port}, grpc to http://localhost:${registry_grpc_port}"
 fi
 
-if [[ $(yq -r ".explorer.enabled" $CONFIGFILE) == "true" ]];
-then
-  kubectl port-forward service/explorer 8080:$EXPLORER_LCD_PORT > /dev/null 2>&1 &
+if [[ $(yq -r ".explorer.enabled" $CONFIGFILE) == "true" ]]; then
+  explorer_port=$(yq -r ".explorer.ports.rest" $CONFIGFILE)
+  explorer_port=${explorer_port:-$EXPLORER_LCD_PORT}
+  kubectl port-forward service/explorer ${explorer_port}:$EXPLORER_LCD_PORT > /dev/null 2>&1 &
   sleep 1
-  color green "Open the explorer to get started.... http://localhost:8080"
+  color green "Open the explorer to get started.... http://localhost:${explorer_port}"
 fi

--- a/examples/injective/scripts/port-forward.sh
+++ b/examples/injective/scripts/port-forward.sh
@@ -74,17 +74,21 @@ done
 
 echo "Port forward services"
 
-if [[ $(yq -r ".registry.enabled" $CONFIGFILE) == "true" ]];
-then
-  kubectl port-forward service/registry 8081:$REGISTRY_LCD_PORT > /dev/null 2>&1 &
-  kubectl port-forward service/registry 9091:$REGISTRY_GRPC_PORT > /dev/null 2>&1 &
+if [[ $(yq -r ".registry.enabled" $CONFIGFILE) == "true" ]]; then
+  registry_lcd_port=$(yq -r ".registry.ports.rest" $CONFIGFILE)
+  registry_grpc_port=$(yq -r ".registry.ports.grpc" $CONFIGFILE)
+  registry_lcd_port=${registry_lcd_port:-$REGISTRY_LCD_PORT}
+  registry_grpc_port=${registry_grpc_port:-$REGISTRY_GRPC_PORT}
+  kubectl port-forward service/registry ${registry_lcd_port}:$REGISTRY_LCD_PORT > /dev/null 2>&1 &
+  kubectl port-forward service/registry ${registry_grpc_port}:$REGISTRY_GRPC_PORT > /dev/null 2>&1 &
   sleep 1
-  color yellow "registry: forwarded registry lcd to grpc http://localhost:8081, to http://localhost:9091"
+  color yellow "registry: forwarded registry lcd to http://localhost:${registry_lcd_port}, grpc to http://localhost:${registry_grpc_port}"
 fi
 
-if [[ $(yq -r ".explorer.enabled" $CONFIGFILE) == "true" ]];
-then
-  kubectl port-forward service/explorer 8080:$EXPLORER_LCD_PORT > /dev/null 2>&1 &
+if [[ $(yq -r ".explorer.enabled" $CONFIGFILE) == "true" ]]; then
+  explorer_port=$(yq -r ".explorer.ports.rest" $CONFIGFILE)
+  explorer_port=${explorer_port:-$EXPLORER_LCD_PORT}
+  kubectl port-forward service/explorer ${explorer_port}:$EXPLORER_LCD_PORT > /dev/null 2>&1 &
   sleep 1
-  color green "Open the explorer to get started.... http://localhost:8080"
+  color green "Open the explorer to get started.... http://localhost:${explorer_port}"
 fi

--- a/examples/multi-chain/scripts/port-forward.sh
+++ b/examples/multi-chain/scripts/port-forward.sh
@@ -74,17 +74,21 @@ done
 
 echo "Port forward services"
 
-if [[ $(yq -r ".registry.enabled" $CONFIGFILE) == "true" ]];
-then
-  kubectl port-forward service/registry 8081:$REGISTRY_LCD_PORT > /dev/null 2>&1 &
-  kubectl port-forward service/registry 9091:$REGISTRY_GRPC_PORT > /dev/null 2>&1 &
+if [[ $(yq -r ".registry.enabled" $CONFIGFILE) == "true" ]]; then
+  registry_lcd_port=$(yq -r ".registry.ports.rest" $CONFIGFILE)
+  registry_grpc_port=$(yq -r ".registry.ports.grpc" $CONFIGFILE)
+  registry_lcd_port=${registry_lcd_port:-$REGISTRY_LCD_PORT}
+  registry_grpc_port=${registry_grpc_port:-$REGISTRY_GRPC_PORT}
+  kubectl port-forward service/registry ${registry_lcd_port}:$REGISTRY_LCD_PORT > /dev/null 2>&1 &
+  kubectl port-forward service/registry ${registry_grpc_port}:$REGISTRY_GRPC_PORT > /dev/null 2>&1 &
   sleep 1
-  color yellow "registry: forwarded registry lcd to grpc http://localhost:8081, to http://localhost:9091"
+  color yellow "registry: forwarded registry lcd to http://localhost:${registry_lcd_port}, grpc to http://localhost:${registry_grpc_port}"
 fi
 
-if [[ $(yq -r ".explorer.enabled" $CONFIGFILE) == "true" ]];
-then
-  kubectl port-forward service/explorer 8080:$EXPLORER_LCD_PORT > /dev/null 2>&1 &
+if [[ $(yq -r ".explorer.enabled" $CONFIGFILE) == "true" ]]; then
+  explorer_port=$(yq -r ".explorer.ports.rest" $CONFIGFILE)
+  explorer_port=${explorer_port:-$EXPLORER_LCD_PORT}
+  kubectl port-forward service/explorer ${explorer_port}:$EXPLORER_LCD_PORT > /dev/null 2>&1 &
   sleep 1
-  color green "Open the explorer to get started.... http://localhost:8080"
+  color green "Open the explorer to get started.... http://localhost:${explorer_port}"
 fi

--- a/examples/neutron/scripts/port-forward.sh
+++ b/examples/neutron/scripts/port-forward.sh
@@ -80,17 +80,21 @@ done
 
 echo "Port forward services"
 
-if [[ $(yq -r ".registry.enabled" $CONFIGFILE) == "true" ]];
-then
-  kubectl port-forward service/registry 8081:$REGISTRY_LCD_PORT > /dev/null 2>&1 &
-  kubectl port-forward service/registry 9091:$REGISTRY_GRPC_PORT > /dev/null 2>&1 &
+if [[ $(yq -r ".registry.enabled" $CONFIGFILE) == "true" ]]; then
+  registry_lcd_port=$(yq -r ".registry.ports.rest" $CONFIGFILE)
+  registry_grpc_port=$(yq -r ".registry.ports.grpc" $CONFIGFILE)
+  registry_lcd_port=${registry_lcd_port:-$REGISTRY_LCD_PORT}
+  registry_grpc_port=${registry_grpc_port:-$REGISTRY_GRPC_PORT}
+  kubectl port-forward service/registry ${registry_lcd_port}:$REGISTRY_LCD_PORT > /dev/null 2>&1 &
+  kubectl port-forward service/registry ${registry_grpc_port}:$REGISTRY_GRPC_PORT > /dev/null 2>&1 &
   sleep 1
-  color yellow "registry: forwarded registry lcd to grpc http://localhost:8081, to http://localhost:9091"
+  color yellow "registry: forwarded registry lcd to http://localhost:${registry_lcd_port}, grpc to http://localhost:${registry_grpc_port}"
 fi
 
-if [[ $(yq -r ".explorer.enabled" $CONFIGFILE) == "true" ]];
-then
-  kubectl port-forward service/explorer 8080:$EXPLORER_LCD_PORT > /dev/null 2>&1 &
+if [[ $(yq -r ".explorer.enabled" $CONFIGFILE) == "true" ]]; then
+  explorer_port=$(yq -r ".explorer.ports.rest" $CONFIGFILE)
+  explorer_port=${explorer_port:-$EXPLORER_LCD_PORT}
+  kubectl port-forward service/explorer ${explorer_port}:$EXPLORER_LCD_PORT > /dev/null 2>&1 &
   sleep 1
-  color green "Open the explorer to get started.... http://localhost:8080"
+  color green "Open the explorer to get started.... http://localhost:${explorer_port}"
 fi

--- a/examples/osmojs/scripts/port-forward.sh
+++ b/examples/osmojs/scripts/port-forward.sh
@@ -64,17 +64,21 @@ done
 
 echo "Port forward services"
 
-if [[ $(yq -r ".registry.enabled" $CONFIGFILE) == "true" ]];
-then
-  kubectl port-forward service/registry 8081:$REGISTRY_LCD_PORT > /dev/null 2>&1 &
-  kubectl port-forward service/registry 9091:$REGISTRY_GRPC_PORT > /dev/null 2>&1 &
+if [[ $(yq -r ".registry.enabled" $CONFIGFILE) == "true" ]]; then
+  registry_lcd_port=$(yq -r ".registry.ports.rest" $CONFIGFILE)
+  registry_grpc_port=$(yq -r ".registry.ports.grpc" $CONFIGFILE)
+  registry_lcd_port=${registry_lcd_port:-$REGISTRY_LCD_PORT}
+  registry_grpc_port=${registry_grpc_port:-$REGISTRY_GRPC_PORT}
+  kubectl port-forward service/registry ${registry_lcd_port}:$REGISTRY_LCD_PORT > /dev/null 2>&1 &
+  kubectl port-forward service/registry ${registry_grpc_port}:$REGISTRY_GRPC_PORT > /dev/null 2>&1 &
   sleep 1
-  color yellow "registry: forwarded registry lcd to grpc http://localhost:8081, to http://localhost:9091"
+  color yellow "registry: forwarded registry lcd to http://localhost:${registry_lcd_port}, grpc to http://localhost:${registry_grpc_port}"
 fi
 
-if [[ $(yq -r ".explorer.enabled" $CONFIGFILE) == "true" ]];
-then
-  kubectl port-forward service/explorer 8080:$EXPLORER_LCD_PORT > /dev/null 2>&1 &
+if [[ $(yq -r ".explorer.enabled" $CONFIGFILE) == "true" ]]; then
+  explorer_port=$(yq -r ".explorer.ports.rest" $CONFIGFILE)
+  explorer_port=${explorer_port:-$EXPLORER_LCD_PORT}
+  kubectl port-forward service/explorer ${explorer_port}:$EXPLORER_LCD_PORT > /dev/null 2>&1 &
   sleep 1
-  color green "Open the explorer to get started.... http://localhost:8080"
+  color green "Open the explorer to get started.... http://localhost:${explorer_port}"
 fi

--- a/starship/scripts/port-forward.sh
+++ b/starship/scripts/port-forward.sh
@@ -107,20 +107,23 @@ fi
 
 
 echo "Port forward services"
-
-if [[ $(yq -r ".registry.enabled" $CONFIGFILE) == "true" ]];
-then
-  kubectl port-forward service/registry 8081:$REGISTRY_LCD_PORT > /dev/null 2>&1 &
-  kubectl port-forward service/registry 9091:$REGISTRY_GRPC_PORT > /dev/null 2>&1 &
+if [[ $(yq -r ".registry.enabled" $CONFIGFILE) == "true" ]]; then
+  registry_lcd_port=$(yq -r ".registry.ports.rest" $CONFIGFILE)
+  registry_grpc_port=$(yq -r ".registry.ports.grpc" $CONFIGFILE)
+  registry_lcd_port=${registry_lcd_port:-$REGISTRY_LCD_PORT}
+  registry_grpc_port=${registry_grpc_port:-$REGISTRY_GRPC_PORT}
+  kubectl port-forward service/registry ${registry_lcd_port}:$REGISTRY_LCD_PORT > /dev/null 2>&1 &
+  kubectl port-forward service/registry ${registry_grpc_port}:$REGISTRY_GRPC_PORT > /dev/null 2>&1 &
   sleep 1
-  color yellow "registry: forwarded registry lcd to grpc http://localhost:8081, to http://localhost:9091"
+  color yellow "registry: forwarded registry lcd to http://localhost:${registry_lcd_port}, grpc to http://localhost:${registry_grpc_port}"
 fi
 
-if [[ $(yq -r ".explorer.enabled" $CONFIGFILE) == "true" ]];
-then
-  kubectl port-forward service/explorer 8080:$EXPLORER_LCD_PORT > /dev/null 2>&1 &
+if [[ $(yq -r ".explorer.enabled" $CONFIGFILE) == "true" ]]; then
+  explorer_port=$(yq -r ".explorer.ports.rest" $CONFIGFILE)
+  explorer_port=${explorer_port:-$EXPLORER_LCD_PORT}
+  kubectl port-forward service/explorer ${explorer_port}:$EXPLORER_LCD_PORT > /dev/null 2>&1 &
   sleep 1
-  color green "Open the explorer to get started.... http://localhost:8080"
+  color green "Open the explorer to get started.... http://localhost:${explorer_port}"
 fi
 
 if [[ $(yq -r ".monitoring.enabled" $CONFIGFILE) == "true" ]];


### PR DESCRIPTION
- if custom ports are provided in config.yaml, the port-forward script did not recognize them
- aiming to have this in [cosmology-tech/starship-action](https://github.com/cosmology-tech/starship-action), which may require a release