### PR TITLE
chore(starship-cli): Add `restartThreshold` as arg in starship cli

### DIFF
--- a/packages/packages/cli/src/utils.ts
+++ b/packages/packages/cli/src/utils.ts
@@ -36,7 +36,8 @@ export const params: string[] = [
   'repoUrl',
   'chart',
   'namespace',
-  'timeout'
+  'timeout',
+  'restartThreshold'
 ];
 
 export const loadConfig = (argv: any): Config => {


### PR DESCRIPTION
Closes:
https://github.com/hyperweb-io/starship/issues/730

This PR adds `restartThreshold` arg/param for starship cli so that we can use `--restartThreshold` during invoking `yarn starship`


