### PR TITLE
chore: update Dockerfile and build script to support custom bin and lib path

### DIFF
--- a/starship/docker/chains/Dockerfile
+++ b/starship/docker/chains/Dockerfile
@@ -2,15 +2,18 @@ ARG BASE_IMAGE
 ARG VERSION
 FROM ${BASE_IMAGE}:${VERSION} AS source
 
-FROM alpine:3.17
+FROM alpine:3.22
+
+ARG BIN_PATH=/bin
+ARG LIB_PATH=/lib
 
 LABEL org.opencontainers.image.source="https://github.com/hyperweb-io/starship"
 
-COPY --from=source /bin /usr/bin
-COPY --from=source /lib /usr/lib
+COPY --from=source ${BIN_PATH} /usr/bin
+COPY --from=source ${LIB_PATH} /usr/lib
 
 # Set up dependencies
-ENV PACKAGES curl make bash jq sed
+ENV PACKAGES="curl make bash jq sed"
 
 # Install minimum necessary dependencies
 RUN apk add --no-cache $PACKAGES

--- a/starship/docker/chains/build-docker-chains.sh
+++ b/starship/docker/chains/build-docker-chains.sh
@@ -51,6 +51,8 @@ build_chain_tag() {
 
   local base=$(yq -r ".chains[] | select(.name==\"$chain\") | .base" versions.yaml)
   local dockerfile=$(yq -r ".chains[] | select(.name==\"$chain\") | .file // \"Dockerfile\"" versions.yaml)
+  local bin_path=$(yq -r ".chains[] | select(.name==\"$chain\") | .bin_path // \"/bin\"" versions.yaml)
+  local lib_path=$(yq -r ".chains[] | select(.name==\"$chain\") | .lib_path // \"/lib\"" versions.yaml)
 
   if [[ "$FORCE" -ne 1 ]]; then
     if image_tag_exists $DOCKER_REPO/$chain $tag; then
@@ -75,6 +77,8 @@ build_chain_tag() {
       . -f $dockerfile \
       --build-arg BASE_IMAGE=$base \
       --build-arg VERSION=$tag \
+      --build-arg BIN_PATH=$bin_path \
+      --build-arg LIB_PATH=$lib_path \
       $buildx_args && break
     color red "failed to build docker image, retrying in 5 seconds, retry: $n"
     sleep 5

--- a/starship/docker/chains/versions.yaml
+++ b/starship/docker/chains/versions.yaml
@@ -9,17 +9,14 @@ chains:
       - v24.0.3
       - v23.0.0
   - name: gaia
-    base: ghcr.io/strangelove-ventures/heighliner/gaia
+    base: ghcr.io/cosmos/gaia
+    bin_path: /usr/local/bin
     tags:
-      - v24.0.0
-      - v23.3.0
-      - v23.2.0
-      - v23.1.1
-      - v21.0.1
-      - v19.2.0
-      - v19.1.0
-      - v18.1.0
-      - v18.0.0
+      - v27.0.0
+      - v26.0.0
+      - v25.3.2
+      - v25.2.0
+      - v25.1.1
   - name: stride
     base: ghcr.io/strangelove-ventures/heighliner/stride
     tags:


### PR DESCRIPTION
## Summary
Chain base images may put binaries in different paths. This change lets you set **binary and library paths** per chain in `versions.yaml` without adding a separate Dockerfile.  
Fixes gaia images where the binary lives in `/usr/local/bin` and was not included when using the shared Dockerfile (which only copied `/bin`).
## Changes
### 1. `docker/chains/Dockerfile`
- Add `ARG BIN_PATH=/bin` and `ARG LIB_PATH=/lib`
- Use `${BIN_PATH}` and `${LIB_PATH}` in `COPY --from=source`
- Use explicit ENV form: `ENV PACKAGES="curl make bash jq sed"` (avoids LegacyKeyValueFormat warning)
### 2. `docker/chains/build-docker-chains.sh`
- Read `bin_path` (default `/bin`) and `lib_path` (default `/lib`) from `versions.yaml`
- Pass them to `docker buildx build` as `--build-arg BIN_PATH` and `--build-arg LIB_PATH`
### 3. `docker/chains/versions.yaml`
- Add `bin_path: /usr/local/bin` for gaia
## Usage
For other chains with different paths, add the options in `versions.yaml` only:
```yaml
  - name: some-chain
    base: ghcr.io/...
    bin_path: /usr/local/bin   # optional; default is /bin
    lib_path: /usr/lib         # optional; default is /lib
    tags:
      - v1.0.0